### PR TITLE
refactor(share): replace deprecated Query.get_or_404 with Session.get

### DIFF
--- a/app/routes/share.py
+++ b/app/routes/share.py
@@ -3,6 +3,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from app import db
 from app.models import Share, User
+from flask import abort
 
 share = Blueprint("share", __name__)
 
@@ -70,7 +71,9 @@ def share_page():
 @share.route("/share/<int:share_id>/revoke", methods=["POST"])
 @login_required
 def revoke_share(share_id):
-    rec = Share.query.get_or_404(share_id)
+    rec = db.session.get(Share, share_id)
+    if not rec:
+        abort(404)
     if rec.from_user_id != current_user.id:
         flash("Not authorised.", "danger")
         return redirect(url_for("share.share_page"))


### PR DESCRIPTION
**What changed**

- Removed the legacy call
`rec = Share.query.get_or_404(share_id)`

- Introduced SQLAlchemy-2.0 style lookup and explicit abort:
```
rec = db.session.get(Share, share_id)
if not rec:
abort(404)
```

**Why**

- Query.get_or_404 relies on the old Query.get() API, which is outdated and deprecated in SQLAlchemy 2.0
- Session.get() eliminates warning

**Effects**

- No change to function: missing shares still return a 404
- Authorization & deletion logic remains untouched

**Testing**

- Verified that an invalid share_id still results in a 404